### PR TITLE
fixes the nested process store and retrieve

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Fixes `ProcessStore.fetch/1`. Now the function is able to retrieve the value from the process
+  dictionary when the process is nested into a process tree.
 
 ## [0.1.0] - 2019-11-26
 ### Added

--- a/lib/process_store.ex
+++ b/lib/process_store.ex
@@ -39,11 +39,9 @@ defmodule ProcessStore do
 
   """
   @spec fetch(key()) :: data()
-  def fetch(key), do: Process.get() |> find_data(key)
+  def fetch(key), do: Process.get(key) || find_data(Process.get(), key)
 
   @spec find_data(keyword(), key()) :: data()
-  defp find_data([{key, value} | _data], wanted_key) when key == wanted_key, do: value
-
   defp find_data([{:"$callers", callers} | _data], key) do
     callers
     |> List.wrap()


### PR DESCRIPTION
When the store call is made inside a process tree and retrieved in the same process, the value returned is `nil`.
This PR fixes the issue.